### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ### 效果演示：
 ![image](https://github.com/renzifeng/ZFTabBar/raw/master/ScreenShot.png)
 
-#用法示例
+# 用法示例
 
 ## 初始化TabBar
 ``` objc


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
